### PR TITLE
Set correct Tunnel Medium type for RADIUS VLAN users

### DIFF
--- a/public/set.php
+++ b/public/set.php
@@ -12,7 +12,7 @@ if ($function == "new-user") {
 
 
 	if (verify_input($username, $password, $vlan)) {
-		$response = $unifi_connection->create_radius_account($username, $password, 13, 1, $vlan);
+		$response = $unifi_connection->create_radius_account($username, $password, 13, 6, $vlan);
 		if ($response) {
 			header('HTTP/1.1 200 OK');
 			echo json_encode($response, JSON_PRETTY_PRINT);


### PR DESCRIPTION
It was setting Tunnel Medium 1 (IPV4) before causing those users to get the wrong ip address, now it's setting Tunnel Medium 6 (802). Might be best to expose a drop down for this in the long run.